### PR TITLE
fix(css): prioritize pf2e icons over system-ui font

### DIFF
--- a/pf2e/components/_variables.scss
+++ b/pf2e/components/_variables.scss
@@ -35,12 +35,12 @@
 		--statblock-font-color: rgb(51, 51, 51);
 		--statblock-font-weight: 400;
 
-		--statblock-content-font: system-ui, "Pathfinder-Actions", -apple-system,
+		--statblock-content-font: "Pathfinder-Actions", system-ui, -apple-system,
 		BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
 		"Open Sans", "Helvetica Neue", sans-serif;
 		--statblock-content-font-size: 13px;
 
-		--statblock-heading-font: system-ui, "Pathfinder-Actions", -apple-system,
+		--statblock-heading-font: "Pathfinder-Actions", system-ui, -apple-system,
 		BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell,
 		"Open Sans", "Helvetica Neue", sans-serif;
 		--statblock-heading-font-color: rgb(51, 51, 51);


### PR DESCRIPTION
When using the plugin on iOS with Pathfinder 2e, the action icons in the bestiary community content, which are ⬽ or similar in the descriptions, don't render using the "Pathfinder" icon font as they do on Windows. This is because the system-ui font takes precedence, and on iOS that font includes these icons.

Related to javalent/fantasy-statblocks#420.