### PR TITLE
Rename Experimental layout to Pathfinder 2e Creature layout

### DIFF
--- a/pf2e/components/_statblock-types.scss
+++ b/pf2e/components/_statblock-types.scss
@@ -1,6 +1,6 @@
 $names: (
 	"basic-pathfinder-2e-layout",
-	"experimental-pathfinder-2e-layout",
+	"pathfinder-2e-creature-layout",
 	"pathfinder-2e-action-layout",
 	"pathfinder-2e-hazard-layout",
 	"pathfinder-2e-influence-layout",

--- a/pf2e/components/font-styling.scss
+++ b/pf2e/components/font-styling.scss
@@ -19,7 +19,7 @@ $statblock-ul-margin: 0 0.5em;
 		a:-webkit-any-link,
 		a.internal-link {
 			color: $statblock-font-color-blue;
-			@if $block_name != "experimental-pathfinder-2e-layout" {
+			@if $block_name != "pathfinder-2e-creature-layout" {
 				font-weight: var(--statblock-property-name-font-weight);
 				text-decoration: none;
 			} @else {

--- a/pf2e/components/property-and-line.scss
+++ b/pf2e/components/property-and-line.scss
@@ -32,6 +32,6 @@
 	}
 }
 
-.statblock.experimental-pathfinder-2e-layout .property-name {
+.statblock.pathfinder-2e-creature-layout .property-name {
 	margin-right: 0;
 }

--- a/pf2e/components/statblock-content.scss
+++ b/pf2e/components/statblock-content.scss
@@ -25,8 +25,8 @@ $statblock-content-margin: 0.5em 2px;
 			padding: $statblock-content-padding;
 			gap: 1rem;
 
-			// Experimental Layout Specific
-			@if $block_name == "experimental-pathfinder-2e-layout" {
+			// Experimental Creature Layout Specific
+			@if $block_name == "pathfinder-2e-creature-layout" {
 				.statblock-item-container.statblock-trait-prop .property.attacks > .property-name  {
 					font-weight: normal;
 					font-style: normal;
@@ -133,7 +133,7 @@ $statblock-content-margin: 0.5em 2px;
 					margin-top: 0;
 				}
 
-				@if $block_name != "experimental-pathfinder-2e-layout" {
+				@if $block_name != "pathfinder-2e-creature-layout" {
 					& > .statblock-item-inline:has(.rare_01,
 						.rare_02,
 						.rare_03,

--- a/pf2e/components/traits.scss
+++ b/pf2e/components/traits.scss
@@ -19,7 +19,7 @@ $statblock-trait-font-style: normal;
 			font-style: $statblock-trait-font-style !important;
 		}
 
-		@if $block_name != "experimental-pathfinder-2e-layout" {
+		@if $block_name != "pathfinder-2e-creature-layout" {
 			.rare_01 {
 				background-color: var(--statblock-color-common) !important;
 				/* common */


### PR DESCRIPTION
Figured this would be less confusing and fits more in with the other layouts. The current layout being a basic one with not many type-specific fields makes sense, whereas this is very tailor-made for creatures in particular.